### PR TITLE
Automatically start minio and teamgramd

### DIFF
--- a/docker-compose-env.yaml
+++ b/docker-compose-env.yaml
@@ -125,6 +125,7 @@ services:
       MINIO_ACCESS_KEY: minio
       MINIO_SECRET_KEY: miniostorage
     command: server /data --console-address ":9001"
+    restart: always
     networks:
       - teamgram_net
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,7 @@ version: "3"
 services:
   teamgram:
     build: .
+    restart: always
     ports:
       - "10443:10443"
       - "20450:20450"


### PR DESCRIPTION
Currently minio and teamgramd has to be started manually after docker launch/system boot.
This change sets these services to restart: always in order to keep them running.