### PR TITLE
bugfix: Android client is unable to change nickname

### DIFF
--- a/app/bff/userprofile/internal/core/account.updateProfile_handler.go
+++ b/app/bff/userprofile/internal/core/account.updateProfile_handler.go
@@ -49,7 +49,7 @@ func (c *UserProfileCore) AccountUpdateProfile(in *mtproto.TLAccountUpdateProfil
 				me.SetAbout(in.GetAbout().GetValue())
 			}
 		}
-	} else {
+	} //else {
 		if in.GetFirstName().GetValue() == "" {
 			err = mtproto.ErrFirstnameInvalid
 			c.Logger.Errorf("account.updateProfile - error: bad request (%v)", err)
@@ -80,7 +80,7 @@ func (c *UserProfileCore) AccountUpdateProfile(in *mtproto.TLAccountUpdateProfil
 				}).To_Update()),
 			})
 		}
-	}
+	//}
 
 	return me.ToSelfUser(), nil
 }


### PR DESCRIPTION
Android client tends to also send about field when user changing nickname, current logic is wrong bcs it will skip modifying nickname if about is set.