### PR TITLE
fix Get{,Featured}EmojiStickers and STICKER_ID_INVALID logspams

### DIFF
--- a/app/bff/bff/client/fake_rpc_result.go
+++ b/app/bff/bff/client/fake_rpc_result.go
@@ -173,6 +173,8 @@ func (c *BFFProxyClient) TryReturnFakeRpcResult(object mtproto.TLObject) (mtprot
 			Stickers: []*mtproto.Document{},
 		}).To_Messages_FavedStickers(), nil
 	case "TLMessagesGetMaskStickers":
+		fallthrough
+	case "TLMessagesGetEmojiStickers":
 		return mtproto.MakeTLMessagesAllStickers(&mtproto.Messages_AllStickers{
 			Hash: 0,
 			Sets: []*mtproto.StickerSet{},
@@ -197,6 +199,8 @@ func (c *BFFProxyClient) TryReturnFakeRpcResult(object mtproto.TLObject) (mtprot
 			Stickers: []*mtproto.Document{},
 		}).To_Messages_Stickers(), nil
 	case "TLMessagesGetFeaturedStickers":
+		fallthrough
+	case "TLMessagesGetFeaturedEmojiStickers":
 		return mtproto.MakeTLMessagesFeaturedStickers(&mtproto.Messages_FeaturedStickers{
 			Count:  0,
 			Hash:   0,
@@ -204,7 +208,7 @@ func (c *BFFProxyClient) TryReturnFakeRpcResult(object mtproto.TLObject) (mtprot
 			Unread: []int64{},
 		}).To_Messages_FeaturedStickers(), nil
 	case "TLMessagesGetStickerSet":
-		return nil, mtproto.ErrStickerIdInvalid
+		return mtproto.MakeTLMessagesStickerSetNotModified(&mtproto.Messages_StickerSet{}).To_Messages_StickerSet(), nil
 
 	// 	scheduledmessages
 	case "TLMessagesGetScheduledMessages":


### PR DESCRIPTION
there likely exist some deadlock in Android client

this commit is based on mytelegram's implementation