### PR TITLE
fix: message forwarding order incorrectly reversed

### DIFF
--- a/app/bff/messages/internal/core/messages.forwardMessages_handler.go
+++ b/app/bff/messages/internal/core/messages.forwardMessages_handler.go
@@ -198,7 +198,8 @@ func (c *MessagesCore) makeForwardMessages(
 
 	fwdOutboxList := make([]*msgpb.OutboxMessage, 0, int(messageList.Length()))
 	groupedIds := make(map[int64]int64)
-	for _, box := range messageList.Datas {
+	for i := len(messageList.Datas) - 1; i >= 0; i-- {
+		box := messageList.Datas[i]
 		m := box.Message
 		// TODO(@benqi): rid is 0
 


### PR DESCRIPTION
also reproduced using https://web.teamgram.net/a/

seems caused by SelectByMessageIdList currently using descending order: https://github.com/teamgram/teamgram-server/blob/5311d90/app/service/biz/message/internal/dal/tables/messages.xml#L35

but cant fix it from there bcs i dont have access to dalgen stuffs, and im afraid simply changing will break other stuffs relying on it