### PR TITLE
fix: unable to edit media or remove caption from message

### DIFF
--- a/app/bff/messages/internal/core/messages.editMessage_handler.go
+++ b/app/bff/messages/internal/core/messages.editMessage_handler.go
@@ -103,7 +103,9 @@ func (c *MessagesCore) MessagesEditMessage(in *mtproto.TLMessagesEditMessage) (*
 	}
 	// message
 	if in.Message != nil {
-		if in.Message.Value == "" {
+		if in.Message.Value == "" &&
+		   (outMessage.Media == nil ||
+		    outMessage.Media.PredicateName == mtproto.Predicate_messageMediaEmpty) {
 			err = mtproto.ErrMessageEmpty
 			c.Logger.Errorf("message empty: %v", err)
 			return nil, err


### PR DESCRIPTION
one notable thing is when editing media which has no caption,
Android client leaves `Message` field nil (standing for unchanged I guess?), so it already works,
but it seems that's not the case with tdesktop.

this commit permits setting empty message value if a media will be present in the final edited message