### PR TITLE
Revert "RFC: fix styled texts on message edit"

### DIFF
--- a/app/bff/messages/internal/core/messages.editMessage_handler.go
+++ b/app/bff/messages/internal/core/messages.editMessage_handler.go
@@ -111,7 +111,7 @@ func (c *MessagesCore) MessagesEditMessage(in *mtproto.TLMessagesEditMessage) (*
 			return nil, err
 		}
 		outMessage.Message = in.Message.Value
-		//outMessage.Entities = nil
+		outMessage.Entities = nil
 		//outMessage, _ = c.fixMessageEntities(c.MD.UserId, peer, in.NoWebpage, outMessage, func() bool {
 		//	hasBot := c.MD.IsBot
 		//	if !hasBot {


### PR DESCRIPTION
This reverts commit 384169d9abfb67a1166c338a626c028de3806506.

Hmm sorry for troubles! it turned out this only worked for trivial cases when i was testing

now i've observed it caused number of dead entities keeps growing on every edit (RemakeMessage keeps creating new for example URL entities for links even if there is already one exist

also other bugs like moving/removing text doesnt move/remove stylings (also causes displaying of URL to glitch

luckily non of these issue seems destructive yet. i think a proper fix for this problem should be made, and better just revert my change for now